### PR TITLE
Add upward jerk effect when deploying parachute

### DIFF
--- a/sky_drop/scripts/Player.gd
+++ b/sky_drop/scripts/Player.gd
@@ -121,8 +121,9 @@ func toggle_parachute():
 	# Reset wind time when deploying parachute
 	if parachute_deployed:
 		wind_time = 0.0
-		# Add initial deployment physics impulse
+		# Add initial deployment physics impulse with upward jerk
 		velocity.y *= 0.6  # Sudden slowdown when parachute opens
+		velocity.y -= 150  # Upward jerk effect
 		velocity.x *= 0.8  # Slight horizontal slowdown
 	
 	# Visual feedback with smooth transitions


### PR DESCRIPTION
## Summary
Adds a realistic upward jerk effect when the parachute deploys, creating better physical feedback.

## Changes
- **Upward jerk**: 150 unit velocity impulse pulls player upward momentarily
- **Enhanced realism**: Mimics real parachute deployment physics
- **Better feedback**: Players feel the parachute "catch" the air

## Physics Sequence
When parachute deploys:
1. Reduce vertical speed by 40% (existing)
2. **NEW**: Apply upward jerk of 150 units
3. Reduce horizontal speed by 20% (existing)

## Before vs After
- **Before**: Smooth deceleration only
- **After**: Sharp upward jerk followed by slower descent

This creates the satisfying "snap back" feeling of a real parachute deployment.

## Test Plan
- [x] Parachute deployment feels more impactful
- [x] Upward jerk is noticeable but not jarring
- [x] Physics transition feels natural
- [x] No negative impact on gameplay flow