### PR TITLE
Add realistic altimeter system with color-coded warnings

### DIFF
--- a/sky_drop/scenes/Main.tscn
+++ b/sky_drop/scenes/Main.tscn
@@ -181,6 +181,14 @@ offset_right = 200.0
 offset_bottom = 96.0
 text = "Parachute: READY"
 
+[node name="AltitudeLabel" type="Label" parent="HUD"]
+offset_left = 10.0
+offset_top = 100.0
+offset_right = 200.0
+offset_bottom = 126.0
+theme_override_font_sizes/font_size = 18
+text = "ALT: 13,500 ft"
+
 [node name="ScoreLabel" type="Label" parent="HUD"]
 offset_left = 170.0
 offset_top = 10.0

--- a/sky_drop/scripts/DevConsole.gd
+++ b/sky_drop/scripts/DevConsole.gd
@@ -183,6 +183,8 @@ func execute_command(command: String):
 			reset_game()
 		"fps":
 			show_fps_info()
+		"altitude":
+			show_altitude_info()
 		_:
 			print_to_console("Unknown command: " + cmd + ". Type 'help' for available commands.")
 
@@ -214,6 +216,7 @@ Audio:
 
 Debug:
 - fps - Show FPS and performance info
+- altitude - Show current altitude and position info
 - clear - Clear console output
 - help - Show this help message
 
@@ -380,6 +383,23 @@ func show_fps_info():
 	info += "Process ID: " + str(process_id)
 	
 	print_to_console(info)
+
+func show_altitude_info():
+	if player:
+		var current_y = player.global_position.y
+		var progress = (current_y - player.STARTING_Y_POSITION) / player.TOTAL_FALL_DISTANCE
+		var altitude = player.current_altitude_feet
+		
+		var info = "=== ALTITUDE INFO ===\n"
+		info += "Current Y Position: " + str(int(current_y)) + "\n"
+		info += "Fall Progress: " + str(int(progress * 100)) + "%\n"
+		info += "Altitude: " + str(altitude) + " ft\n"
+		info += "Distance Fallen: " + str(int(player.STARTING_ALTITUDE_FEET - altitude)) + " ft\n"
+		info += "Distance to Ground: " + str(altitude) + " ft"
+		
+		print_to_console(info)
+	else:
+		print_to_console("Player not found!")
 
 # Sound Menu Callbacks
 func _on_master_volume_changed(value: float):

--- a/sky_drop/scripts/HUD.gd
+++ b/sky_drop/scripts/HUD.gd
@@ -5,6 +5,7 @@ extends CanvasLayer
 @onready var parachute_label = $ParachuteLabel
 @onready var score_label = $ScoreLabel
 @onready var combo_label = $ComboLabel
+@onready var altitude_label = $AltitudeLabel
 
 var game_manager
 
@@ -14,6 +15,11 @@ func _ready():
 		game_manager.connect("time_updated", _on_time_updated)
 		game_manager.connect("score_updated", _on_score_updated)
 		game_manager.connect("combo_updated", _on_combo_updated)
+	
+	# Connect to player for altitude updates
+	var player = get_node("/root/Main/Player")
+	if player:
+		player.connect("altitude_changed", _on_altitude_changed)
 
 func _on_time_updated(time):
 	if time_label:
@@ -40,6 +46,29 @@ func _on_combo_updated(combo_count: int, multiplier: int):
 			combo_label.visible = true
 		else:
 			combo_label.visible = false
+
+func _on_altitude_changed(altitude_feet: int):
+	if altitude_label:
+		# Format altitude with nice styling like real altimeters
+		var altitude_text = format_altitude(altitude_feet)
+		altitude_label.text = altitude_text
+		
+		# Color coding based on altitude
+		if altitude_feet <= 2500:  # Below recommended minimum deployment altitude
+			altitude_label.modulate = Color.RED
+		elif altitude_feet <= 5000:  # Caution zone
+			altitude_label.modulate = Color.YELLOW
+		else:  # Safe zone
+			altitude_label.modulate = Color.WHITE
+
+func format_altitude(feet: int) -> String:
+	# Format like real skydiving altimeters
+	if feet >= 10000:
+		return "ALT: %d,000 ft" % [feet / 1000]
+	elif feet >= 1000:
+		return "ALT: %d,%03d ft" % [feet / 1000, feet % 1000]
+	else:
+		return "ALT: %d ft" % feet
 
 func show_game_over(final_time, lives_remaining):
 	var game_over_text = "GAME OVER\n"

--- a/sky_drop/scripts/ParticleCloud.gd.uid
+++ b/sky_drop/scripts/ParticleCloud.gd.uid
@@ -1,0 +1,1 @@
+uid://gm6w6erce35f


### PR DESCRIPTION
## Summary
- Added realistic altimeter display showing altitude from 13,500 ft to ground level
- Implemented color-coded warnings: RED below 2,500 ft, YELLOW below 5,000 ft
- Connected real-time altitude tracking from Player to HUD display
- Added "altitude" debug command to dev console

## Test plan
- [ ] Verify altimeter displays correct starting altitude (13,500 ft)
- [ ] Check color changes at warning thresholds (2,500 ft and 5,000 ft)
- [ ] Test altitude updates smoothly during gameplay
- [ ] Confirm "altitude" console command shows detailed info