### PR TITLE
Add game credits to title screen

### DIFF
--- a/sky_drop/scenes/MainMenu.tscn
+++ b/sky_drop/scenes/MainMenu.tscn
@@ -64,5 +64,51 @@ layout_mode = 2
 texture_normal = ExtResource("5")
 stretch_mode = 5
 
+[node name="CreditsContainer" type="VBoxContainer" parent="."]
+layout_mode = 0
+anchor_left = 0.5
+anchor_top = 0.85
+anchor_right = 0.5
+anchor_bottom = 0.95
+offset_left = -160.0
+offset_top = -40.0
+offset_right = 160.0
+offset_bottom = 40.0
+
+[node name="CreditsTitle" type="Label" parent="CreditsContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "Created by"
+horizontal_alignment = 1
+
+[node name="MiloCredit" type="RichTextLabel" parent="CreditsContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+bbcode_enabled = true
+text = "[center][url=https://milocurran.github.io/]Milo Curran[/url][/center]"
+fit_content = true
+
+[node name="AlanCredit" type="RichTextLabel" parent="CreditsContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+bbcode_enabled = true
+text = "[center][url=https://promptcade.com/alanson]Alan Son[/url][/center]"
+fit_content = true
+
+[node name="VersionLabel" type="Label" parent="."]
+layout_mode = 0
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -80.0
+offset_top = -25.0
+text = "v1.0.0"
+horizontal_alignment = 2
+theme_override_font_sizes/font_size = 12
+theme_override_colors/font_color = Color(1, 1, 1, 0.7)
+
 [connection signal="pressed" from="VBoxContainer/StartButton" to="." method="_on_start_button_pressed"]
 [connection signal="pressed" from="VBoxContainer/QuitButton" to="." method="_on_quit_button_pressed"]
+[connection signal="meta_clicked" from="CreditsContainer/MiloCredit" to="." method="_on_credit_link_clicked"]
+[connection signal="meta_clicked" from="CreditsContainer/AlanCredit" to="." method="_on_credit_link_clicked"]

--- a/sky_drop/scripts/MainMenu.gd
+++ b/sky_drop/scripts/MainMenu.gd
@@ -1,7 +1,16 @@
 extends Control
 
+@onready var milo_credit = $CreditsContainer/MiloCredit
+@onready var alan_credit = $CreditsContainer/AlanCredit
+
 func _ready():
 	$VBoxContainer/StartButton.grab_focus()
+	
+	# Connect clickable credits
+	if milo_credit:
+		milo_credit.meta_clicked.connect(_on_credit_link_clicked)
+	if alan_credit:
+		alan_credit.meta_clicked.connect(_on_credit_link_clicked)
 
 func _input(event):
 	if Input.is_action_just_pressed("reset_game"):
@@ -12,3 +21,7 @@ func _on_start_button_pressed():
 
 func _on_quit_button_pressed():
 	get_tree().quit()
+
+func _on_credit_link_clicked(meta):
+	# Open the URL in default browser
+	OS.shell_open(str(meta))


### PR DESCRIPTION
## Summary
Added developer credits section to the main menu title screen with clickable links to developer portfolios.

## Changes
- **Credits Section**: Added at bottom of main menu (85% height position)
- **Developer Links**: 
  - Milo Curran → https://milocurran.github.io/
  - Alan Son → https://promptcade.com/alanson
- **Interactive Links**: Clicking opens URLs in default browser
- **Version Label**: Added v1.0.0 in bottom right corner
- **Professional Layout**: Centered credits with clean presentation

## Implementation Details
- Uses RichTextLabel with BBCode for clickable links
- `OS.shell_open()` to open URLs in browser
- Connected `meta_clicked` signals for link functionality
- Positioned to not interfere with main UI elements

## Visual Design
- "Created by" header with developer names below
- Clickable blue hyperlinks that stand out
- Semi-transparent version number in corner
- Maintains Sky Drop's visual theme

Ready to merge\!