### PR TITLE
Add credits to Game Over screen

### DIFF
--- a/sky_drop/scenes/GameOver.tscn
+++ b/sky_drop/scenes/GameOver.tscn
@@ -59,5 +59,41 @@ layout_mode = 2
 texture_normal = ExtResource("3")
 stretch_mode = 5
 
+[node name="CreditsContainer" type="VBoxContainer" parent="."]
+layout_mode = 0
+anchor_left = 0.5
+anchor_top = 0.85
+anchor_right = 0.5
+anchor_bottom = 0.95
+offset_left = -160.0
+offset_top = -30.0
+offset_right = 160.0
+offset_bottom = 30.0
+
+[node name="CreditsTitle" type="Label" parent="CreditsContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 14
+theme_override_colors/font_color = Color(1, 1, 1, 0.8)
+text = "Created by"
+horizontal_alignment = 1
+
+[node name="MiloCredit" type="RichTextLabel" parent="CreditsContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+bbcode_enabled = true
+theme_override_font_sizes/normal_font_size = 12
+text = "[center][url=https://milocurran.github.io/]Milo Curran[/url][/center]"
+fit_content = true
+
+[node name="AlanCredit" type="RichTextLabel" parent="CreditsContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+bbcode_enabled = true
+theme_override_font_sizes/normal_font_size = 12
+text = "[center][url=https://promptcade.com/alanson]Alan Son[/url][/center]"
+fit_content = true
+
 [connection signal="pressed" from="VBoxContainer/RetryButton" to="." method="_on_retry_button_pressed"]
 [connection signal="pressed" from="VBoxContainer/MenuButton" to="." method="_on_menu_button_pressed"]
+[connection signal="meta_clicked" from="CreditsContainer/MiloCredit" to="." method="_on_credit_link_clicked"]
+[connection signal="meta_clicked" from="CreditsContainer/AlanCredit" to="." method="_on_credit_link_clicked"]

--- a/sky_drop/scripts/GameOver.gd
+++ b/sky_drop/scripts/GameOver.gd
@@ -1,10 +1,19 @@
 extends Control
 
+@onready var milo_credit = $CreditsContainer/MiloCredit
+@onready var alan_credit = $CreditsContainer/AlanCredit
+
 func _ready():
 	$VBoxContainer/RetryButton.grab_focus()
 	
 	# Load and display the game results
 	display_results()
+	
+	# Connect clickable credits
+	if milo_credit:
+		milo_credit.meta_clicked.connect(_on_credit_link_clicked)
+	if alan_credit:
+		alan_credit.meta_clicked.connect(_on_credit_link_clicked)
 
 func _input(event):
 	if Input.is_action_just_pressed("reset_game"):
@@ -25,6 +34,10 @@ func _on_retry_button_pressed():
 
 func _on_menu_button_pressed():
 	get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
+
+func _on_credit_link_clicked(meta):
+	# Open the URL in default browser
+	OS.shell_open(str(meta))
 
 func display_results():
 	print("GameOver: Displaying results - Score: ", GameData.final_score, " Time: ", GameData.final_time)


### PR DESCRIPTION
## Summary
Extended the credits feature to include developer credits on the Game Over screen for consistent branding across all game screens.

## Changes
- **Credits Section**: Added at bottom of Game Over screen (85% height position)
- **Developer Links**: 
  - Milo Curran → https://milocurran.github.io/
  - Alan Son → https://promptcade.com/alanson
- **Interactive Links**: Clicking opens URLs in default browser
- **Consistent Design**: Matches main menu credits styling

## Implementation Details
- Uses RichTextLabel with BBCode for clickable links
- `OS.shell_open()` to open URLs in browser
- Connected `meta_clicked` signals for link functionality
- Smaller font size (12px) to fit Game Over layout
- Semi-transparent styling to complement dark overlay

## Visual Design
- Positioned below score/time results
- "Created by" header with developer names below
- Clickable blue hyperlinks
- Doesn't interfere with retry/menu buttons
- Maintains consistency with main menu

## Testing
- [x] Credits display correctly after game over
- [x] Links are clickable and open correct URLs
- [x] Layout doesn't interfere with existing UI elements
- [x] Styling matches overall game theme

Ready to merge - completes the credits implementation across all screens\!